### PR TITLE
Allow queue name to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ for new blocks.
 
 ## Contribute and Test
 
+Before running the tests, you'll have to run through the configuration described
+above.
+
 ```
 $ git clone git@github.com:leapdao/challenge-services.git
 $ cd challenge-services

--- a/config/index_template.json
+++ b/config/index_template.json
@@ -4,13 +4,13 @@
     "options": {
       "host": "The redis host",
       "port": 6379
-    },
-    "queue": {
-      "name": "The name of the queue holding all contract events"
     }
   },
   "contracts": [{
     "address": "A contract address that should be listened to for events",
-    "ABI": "A valid JSON ABI of the contract at the above specified address"
+    "ABI": "A valid JSON ABI of the contract at the above specified address",
+    "queue": {
+      "name": "The name of the queue holding all events for this contract"
+    }
   }]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   event_scanner:
     container_name: event_scanner
     build: .
-    volumes:
-      - ./db:/home/data
     secrets:
       - redis_pass
     depends_on:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/run.js",
   "scripts": {
     "start": "node src/run.js",
-    "test": "mocha test"
+    "test": "mocha --recursive"
   },
   "repository": {
     "type": "git",

--- a/src/events/init.js
+++ b/src/events/init.js
@@ -10,6 +10,7 @@ const web3 = new Web3(config.endpoint);
 
 function initContracts() {
   const contracts = [];
+  const queueNames = [];
   for (let i = 0; i < config.contracts.length; i++) {
     contracts.push(
       new web3.eth.Contract(
@@ -17,11 +18,15 @@ function initContracts() {
         config.contracts[i].address
       )
     );
+    queueNames.push(config.contracts[i].queue.name);
   }
-  return contracts;
+  return {
+    contracts,
+    queueNames
+  };
 }
 
-async function initRSMQ(password) {
+async function initRSMQ(password, queueNames) {
   const rsmq = new RSMQPromise({
     host: config.redis.options.host,
     port: config.redis.options.port,
@@ -30,7 +35,7 @@ async function initRSMQ(password) {
   });
 
   // NOTE: On first run, a queue might not exist yet, so we need to create it.
-  await initQueue(rsmq);
+  await initQueues(rsmq, queueNames);
 
   return rsmq;
 }
@@ -56,26 +61,34 @@ function initDB(password) {
 async function init() {
   // NOTE: It's important to trim the secret file from whitespaces
   const password = fs.readFileSync("/run/secrets/redis_pass", "utf8").trim();
+  const { contracts, queueNames } = initContracts();
 
   return {
-    contracts: initContracts(),
-    rsmq: await initRSMQ(password),
+    contracts,
+    queueNames,
+    rsmq: await initRSMQ(password, queueNames),
     db: initDB(password),
     web3: web3
   };
 }
 
-async function initQueue(rsmq) {
-  try {
-    await rsmq.getQueueAttributes({ qname: config.redis.queue.name });
-  } catch (err) {
-    console.log("No matching redis queue found. Creating a new one");
+async function initQueues(rsmq, queueNames) {
+  for (let i = 0; i < queueNames.length; i++) {
+    const qname = queueNames[i];
+
     try {
-      await rsmq.createQueue({ qname: config.redis.queue.name });
-      console.log("Queue successfully created...");
+      await rsmq.getQueueAttributes({ qname });
     } catch (err) {
-      console.log(err);
-      process.exit(1);
+      console.log(
+        `No matching redis queue found for queue name ${qname}. Creating a new one.`
+      );
+      try {
+        await rsmq.createQueue({ qname });
+        console.log("Queue successfully created...");
+      } catch (err) {
+        console.log(err);
+        process.exit(1);
+      }
     }
   }
 }

--- a/test/events/index.test.js
+++ b/test/events/index.test.js
@@ -16,26 +16,12 @@ describe("Event Scanner", () => {
         .resolves(null),
       set: sinon.fake.resolves("Saved")
     };
-    const getLocalHeights = rewire("../src/events").__get__("getLocalHeights");
+    const getLocalHeights = rewire("../../src/events").__get__(
+      "getLocalHeights"
+    );
 
-    const contracts = [
-      {
-        options: {
-          address: "abc"
-        }
-      },
-      {
-        options: {
-          address: "abc2"
-        }
-      },
-      {
-        options: {
-          address: "abc3"
-        }
-      }
-    ];
-    const heights = await getLocalHeights(db, contracts);
+    const addresses = ["abc", "bde", "fgh"];
+    const heights = await getLocalHeights(db, addresses);
 
     assert.deepEqual(
       heights,

--- a/test/events/init.test.js
+++ b/test/events/init.test.js
@@ -1,0 +1,59 @@
+// @format
+const { assert } = require("chai");
+const rewire = require("rewire");
+const sinon = require("sinon");
+
+describe("Init", () => {
+  it("should return initialized web3 contracts and queue names", () => {
+    const expected = {
+      address: "0x0000000000000000000000000000000000000000",
+      ABI: [
+        {
+          constant: true,
+          inputs: [],
+          name: "name",
+          outputs: [
+            {
+              name: "",
+              type: "string"
+            }
+          ],
+          payable: false,
+          stateMutability: "view",
+          type: "function"
+        }
+      ],
+      queue: {
+        name: "queue"
+      }
+    };
+
+    const events = rewire("../../src/events/init");
+    events.__set__("config", {
+      contracts: [expected]
+    });
+
+    const initContracts = events.__get__("initContracts");
+    const { contracts, queueNames } = initContracts();
+
+    assert.deepEqual(queueNames, [expected.queue.name]);
+    assert(contracts[0].options.address === expected.address);
+  });
+
+  it("should create a queue if it doesn't exist yet", async () => {
+    const initQueue = rewire("../../src/events/init").__get__("initQueue");
+    const rsmqStub = {
+      getQueueAttributes: sinon.fake.throws(),
+      createQueue: sinon.fake.resolves(1)
+    };
+
+    const expectedQueueName = "queue_name";
+    await initQueue(rsmqStub, [expectedQueueName]);
+
+    assert(rsmqStub.getQueueAttributes.callCount === 1);
+    assert(rsmqStub.createQueue.callCount === 1);
+    assert.deepEqual(rsmqStub.createQueue.lastArg, {
+      qname: expectedQueueName
+    });
+  });
+});


### PR DESCRIPTION
Fixes #5 

What was done:

- config now allows to specify a queue per contract
- `initQueue` can now initialize multiple queues
- Added a bunch of tests around `events/init.js`
- Events are now written into queue specified in config

TODOs:

- [x] Rebase this PR once #1 is merged