### PR TITLE
AWS ECS deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,4 @@ COPY . /usr/src/event-scanner
 
 # Run the command on container startup
 CMD ["cron", "-f"]
+#CMD ["/usr/local/bin/node", "/usr/src/event-scanner/src/run.js"]

--- a/README.md
+++ b/README.md
@@ -28,13 +28,21 @@ for new blocks.
 
 1. Install ECS-CLI
 1. Create a ECS cluster configuration locally: `ecs-cli configure --cluster challenge-services --default-launch-type FARGATE --region eu-central-1`
-1. `ecs-cli up` creates a cluster. Note down the two created subnets and add them to `ecs-params.yml`
-1. `ecs-cli compose --cluster default --file docker-compose.yml service up`
+1. `ecs-cli --cluster challenge-services up` creates a cluster. Note down the two created subnets and add them to `ecs-params.yml`
+1. `ecs-cli compose --cluster challenge-services --file docker-compose.yml service up`
 
 Helpful pages:
 
 - https://medium.com/@peatiscoding/docker-compose-ecs-91b033c8fdb6
 - https://www.bogotobogo.com/DevOps/Docker/Docker-ECS-CLI-Docker-Compose-Wordpress-Fargate-Type.php
+
+### Logging
+
+To get information about logging:
+
+```
+ecs-cli logs --task-id 7ab94d08-e6f1-4907-a974-30ee154e68b4 --container-name event_scanner
+```
 
 ## Contribute and Test
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# event-scanner
+# challenge-services
 
 > A JavaScript tool to scan smart contract events on Ethereum
 
@@ -23,6 +23,18 @@ for new blocks.
 ## Installation
 
 1. To build and run the container: `docker-compose up --build`
+
+## Deploy to AWS ECS
+
+1. Install ECS-CLI
+1. Create a ECS cluster configuration locally: `ecs-cli configure --cluster challenge-services --default-launch-type FARGATE --region eu-central-1`
+1. `ecs-cli up` creates a cluster. Note down the two created subnets and add them to `ecs-params.yml`
+1. `ecs-cli compose --cluster default --file docker-compose.yml service up`
+
+Helpful pages:
+
+- https://medium.com/@peatiscoding/docker-compose-ecs-91b033c8fdb6
+- https://www.bogotobogo.com/DevOps/Docker/Docker-ECS-CLI-Docker-Compose-Wordpress-Fargate-Type.php
 
 ## Contribute and Test
 

--- a/config/index_template.json
+++ b/config/index_template.json
@@ -4,13 +4,13 @@
     "options": {
       "host": "The redis host",
       "port": 6379
-    },
-    "queue": {
-      "name": "The name of the queue holding all contract events"
     }
   },
   "contracts": [{
     "address": "A contract address that should be listened to for events",
-    "ABI": "A valid JSON ABI of the contract at the above specified address"
+    "ABI": "A valid JSON ABI of the contract at the above specified address",
+    "queue": {
+      "name": "The name of the queue holding all events for this contract"
+    }
   }]
 }

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  event_scanner:
+    container_name: event_scanner
+    build: .
+    depends_on:
+      - redis
+    environment:
+      - REDIS_PASS
+  redis:
+    container_name: redis
+    image: redis
+    volumes:
+      - /data
+    command: ["sh", "-c", "redis-server --requirepass $REDIS_PASS --appendonly \"yes\""]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
         driver: awslogs
         options:
           awslogs-region: eu-central-1
-          awslogs-group: challenge-services
-          awslogs-stream-prefix: lol
+          awslogs-group: challenge-services/event_scanner
+          awslogs-stream-prefix: event_scanner_logs
   redis:
     container_name: redis
     image: redis
@@ -21,5 +21,5 @@ services:
         driver: awslogs
         options:
           awslogs-region: eu-central-1
-          awslogs-group: challenge-services
-          awslogs-stream-prefix: lol
+          awslogs-group: challenge-services/redis
+          awslogs-stream-prefix: redis_logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,25 @@
-version: "3.1"
+version: "3"
 services:
   event_scanner:
     container_name: event_scanner
-    build: .
-    volumes:
-      - ./db:/home/data
-    secrets:
-      - redis_pass
+    image: timdaub/challenge-services
     depends_on:
       - redis
+    logging:
+        driver: awslogs
+        options:
+          awslogs-region: eu-central-1
+          awslogs-group: challenge-services
+          awslogs-stream-prefix: lol
   redis:
     container_name: redis
     image: redis
     volumes:
-      - ./redis:/data
-    command: ["sh", "-c", "redis-server --requirepass \"$$(cat /run/secrets/redis_pass)\" --appendonly \"yes\""]
-    secrets:
-      - redis_pass
-secrets:
-  redis_pass:
-    file: ./config/redis_pass.txt
+      - /data
+    command: ["sh", "-c", "redis-server --appendonly \"yes\""]
+    logging:
+        driver: awslogs
+        options:
+          awslogs-region: eu-central-1
+          awslogs-group: challenge-services
+          awslogs-stream-prefix: lol

--- a/ecs-params.yml
+++ b/ecs-params.yml
@@ -5,10 +5,13 @@ task_definition:
   task_size:
     mem_limit: 0.5GB
     cpu_limit: 256
+  secrets:
+    name: REDIS_PASS
+    valueFrom: arn:aws:ssm:region:aws_account_id:challenge-services/redis_pass
 run_params:
   network_configuration:
     awsvpc_configuration:
       subnets:
-        - "subnet-0902eb996f7cac2ab"
+        - "subnet-098d2fa0ee6f1e00d"
         - "subnet-098d2fa0ee6f1e00d"
       assign_public_ip: ENABLED

--- a/ecs-params.yml
+++ b/ecs-params.yml
@@ -1,0 +1,14 @@
+version: 1
+task_definition:
+  task_execution_role: ecsTaskExecutionRole
+  ecs_network_mode: awsvpc
+  task_size:
+    mem_limit: 0.5GB
+    cpu_limit: 256
+run_params:
+  network_configuration:
+    awsvpc_configuration:
+      subnets:
+        - "subnet-0902eb996f7cac2ab"
+        - "subnet-098d2fa0ee6f1e00d"
+      assign_public_ip: ENABLED

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/run.js",
   "scripts": {
     "start": "node src/run.js",
-    "test": "mocha test"
+    "test": "mocha --recursive"
   },
   "repository": {
     "type": "git",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,6 @@
+# Build new image and deploy it to registry
+# Ask for region and cluster name
+ecs-cli configure --cluster challenge-services --default-launch-type FARGATE --region eu-central-1
+# Get subnets from command
+ecs-cli up --cluster challenge-services
+ecs-cli compose --cluster challenge-services --file docker-compose.yml service up

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -5,8 +5,10 @@ const config = require("../../config");
 const init = require("./init");
 
 async function run() {
-  const { db, web3, rsmq, contracts } = await init();
-  const localHeights = await getLocalHeights(db, contracts);
+  const { db, web3, rsmq, contracts, queueNames } = await init();
+
+  const addresses = contracts.map(c => c.options.address);
+  const localHeights = await getLocalHeights(db, addresses);
   const diffs = await getDifferences(web3, localHeights);
 
   for (let i = 0; i < contracts.length; i++) {
@@ -20,18 +22,32 @@ async function run() {
       console.log("Nothing to scan...");
       // noop
     } else {
-      console.log(`Contract ${contract.options.address} is at local height ${localHeight} (diff: ${diff})`);
+      console.log(
+        `Contract ${
+          contract.options.address
+        } is at local height ${localHeight} (diff: ${diff})`
+      );
       const events = await scan(contract, localHeight, diff);
       if (events.length <= 0) {
         console.log(`No new events for contract ${contract.options.address}`);
         await db.set(`${contract.options.address}_height`, localHeight + diff);
       } else {
         try {
-          await send(rsmq, events);
+          await send(rsmq, queueNames[i], events);
         } catch (err) {
-          console.log("Failed to send all events", err);
+          console.log(
+            `Failed to send all events for contract ${
+              contract.options.address
+            }`,
+            err
+          );
+          continue;
         }
-        console.log(`Successfully wrote ${events.length} events to queue for contract: ${contract.options.address}.`);
+        console.log(
+          `Successfully wrote ${events.length} events to queue for contract: ${
+            contract.options.address
+          }.`
+        );
         await db.set(`${contract.options.address}_height`, localHeight + diff);
       }
     }
@@ -51,10 +67,10 @@ async function teardown(db, rsmq) {
   }
 }
 
-async function send(rsmq, events) {
+async function send(rsmq, qname, events) {
   const p = events.map(e => {
     return rsmq.sendMessage({
-      qname: config.redis.queue.name,
+      qname,
       message: JSON.stringify(e)
     });
   });
@@ -74,8 +90,8 @@ async function getDifferences(web3, localHeights) {
   return localHeights.map(h => remoteHeight - h);
 }
 
-async function getLocalHeights(db, contracts) {
-  const queries = contracts.map(c => `${c.options.address}_height`);
+async function getLocalHeights(db, addresses) {
+  const queries = addresses.map(a => `${a}_height`);
   let p = queries.map(q => db.get(q));
 
   // NOTE: If values have not been set yet in redis, then it returns
@@ -91,10 +107,10 @@ async function getLocalHeights(db, contracts) {
       (acc, curr, i) =>
         // NOTE: We're using `concat` instead of `push` here to return the
         // update array to the reduce function.
-        curr === 0 ? acc.concat([contracts[i].options.address]) : acc,
+        curr === 0 ? acc.concat([addresses[i]]) : acc,
       []
     )
-    .map(c => db.set(`${c}_height`, "0"));
+    .map(a => db.set(`${a}_height`, "0"));
   await Promise.all(p);
 
   return heights;

--- a/src/events/init.js
+++ b/src/events/init.js
@@ -37,6 +37,7 @@ async function initRSMQ(password, queueNames) {
   // NOTE: On first run, a queue might not exist yet, so we need to create it.
   await initQueue(rsmq, queueNames);
 
+  console.log("hi");
   return rsmq;
 }
 
@@ -59,8 +60,8 @@ function initDB(password) {
 }
 
 async function init() {
-  // NOTE: It's important to trim the secret file from whitespaces
-  const password = fs.readFileSync("/run/secrets/redis_pass", "utf8").trim();
+  console.log(process.env.REDIS_PASS);
+  const password = process.env.REDIS_PASS;
   const { contracts, queueNames } = initContracts();
 
   return {

--- a/test/events/index.test.js
+++ b/test/events/index.test.js
@@ -16,26 +16,12 @@ describe("Event Scanner", () => {
         .resolves(null),
       set: sinon.fake.resolves("Saved")
     };
-    const getLocalHeights = rewire("../src/events").__get__("getLocalHeights");
+    const getLocalHeights = rewire("../../src/events").__get__(
+      "getLocalHeights"
+    );
 
-    const contracts = [
-      {
-        options: {
-          address: "abc"
-        }
-      },
-      {
-        options: {
-          address: "abc2"
-        }
-      },
-      {
-        options: {
-          address: "abc3"
-        }
-      }
-    ];
-    const heights = await getLocalHeights(db, contracts);
+    const addresses = ["abc", "bde", "fgh"];
+    const heights = await getLocalHeights(db, addresses);
 
     assert(
       db.set.callCount === 2 && db.set.lastArg === "0",

--- a/test/events/init.test.js
+++ b/test/events/init.test.js
@@ -1,0 +1,59 @@
+// @format
+const { assert } = require("chai");
+const rewire = require("rewire");
+const sinon = require("sinon");
+
+describe("Init", () => {
+  it("should return initialized web3 contracts and queue names", () => {
+    const expected = {
+      address: "0x0000000000000000000000000000000000000000",
+      ABI: [
+        {
+          constant: true,
+          inputs: [],
+          name: "name",
+          outputs: [
+            {
+              name: "",
+              type: "string"
+            }
+          ],
+          payable: false,
+          stateMutability: "view",
+          type: "function"
+        }
+      ],
+      queue: {
+        name: "queue"
+      }
+    };
+
+    const events = rewire("../../src/events/init");
+    events.__set__("config", {
+      contracts: [expected]
+    });
+
+    const initContracts = events.__get__("initContracts");
+    const { contracts, queueNames } = initContracts();
+
+    assert.deepEqual(queueNames, [expected.queue.name]);
+    assert(contracts[0].options.address === expected.address);
+  });
+
+  it("should create a queue if it doesn't exist yet", async () => {
+    const initQueue = rewire("../../src/events/init").__get__("initQueue");
+    const rsmqStub = {
+      getQueueAttributes: sinon.fake.throws(),
+      createQueue: sinon.fake.resolves(1)
+    };
+
+    const expectedQueueName = "queue_name";
+    await initQueue(rsmqStub, [expectedQueueName]);
+
+    assert(rsmqStub.getQueueAttributes.callCount === 1);
+    assert(rsmqStub.createQueue.callCount === 1);
+    assert.deepEqual(rsmqStub.createQueue.lastArg, {
+      qname: expectedQueueName
+    });
+  });
+});


### PR DESCRIPTION
Fixes #4

## Description

- Allows to deploy docker container into AWS ECS

## Problems of AWS ECS

- need of creating a ecs-params.yml file
- Cannot use docker-compose.yml version > 3
- Tight integration with AWS is required
  - log drivers of containers need to use AWS driver
  - AWS Secret Store must be used. This also means a CloudFormation template will be required, as you have to give permissions to the containers to access the store
  - ecs-cli and ECS in general is more of a docker clone than a docker hosting service. Ideally, they'd like you to use their own specification files (ecs-params.yml)
  - `build` keyword in docker-compose.yml is not supported. On every redeploy, a new image has to be uploaded to a container registry like dockerhub

## TODOs:

- [ ] Make sure everything is reproducable
- [x] Setup proper logging
- [ ] Change Docker Secrets managment
- [ ] Convert README.md deployment instructions into script