### PR TITLE
Deploy challenge services to AWS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 db
 config/redis_pass.txt
+config/index.json
 .DS_Store
 redis

--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ $ mv config/index_template.json config/index.json
 Fill in all the relevant information. The template file contains a rough
 documentation of the fields.
 
-This service uses a redis instance to store its local block height and uses it
-as a queue (rsmq). We use Docker Secrets to propagate the redis password.
-Generate a secure password and store it in `config/redis_pass.txt`.
-
 In `config/crontab`, define the frequency with which the service should scan
 for new blocks.
 

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -1,0 +1,18 @@
+version: "3.1"
+services:
+  event_scanner:
+    container_name: event_scanner
+    image: timdaub/challenge-services
+    depends_on:
+      - redis
+  redis:
+    container_name: redis
+    image: redis
+    volumes:
+      - ./redis:/data
+    command: ["sh", "-c", "redis-server --appendonly \"yes\""]
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: event_scanner --interval 30

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -5,6 +5,8 @@ services:
     image: quay.io/leapdao/challenge-services
     depends_on:
       - redis
+    volumes:
+      - ./config/index.json:/usr/src/event-scanner/config/index.json
   redis:
     container_name: redis
     image: redis

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -2,7 +2,7 @@ version: "3.1"
 services:
   event_scanner:
     container_name: event_scanner
-    image: timdaub/challenge-services
+    image: quay.io/leapdao/challenge-services
     depends_on:
       - redis
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build: .
     depends_on:
       - redis
+    volumes:
+      - ./config/index.json:/usr/src/event-scanner/config/index.json
   redis:
     container_name: redis
     image: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   event_scanner:
     container_name: event_scanner
     build: .
-    secrets:
-      - redis_pass
     depends_on:
       - redis
   redis:
@@ -12,9 +10,4 @@ services:
     image: redis
     volumes:
       - ./redis:/data
-    command: ["sh", "-c", "redis-server --requirepass \"$$(cat /run/secrets/redis_pass)\" --appendonly \"yes\""]
-    secrets:
-      - redis_pass
-secrets:
-  redis_pass:
-    file: ./config/redis_pass.txt
+    command: ["sh", "-c", "redis-server --appendonly \"yes\""]

--- a/src/events/init.js
+++ b/src/events/init.js
@@ -26,12 +26,11 @@ function initContracts() {
   };
 }
 
-async function initRSMQ(password, queueNames) {
+async function initRSMQ(queueNames) {
   const rsmq = new RSMQPromise({
     host: config.redis.options.host,
     port: config.redis.options.port,
-    ns: "rsmq",
-    password
+    ns: "rsmq"
   });
 
   // NOTE: On first run, a queue might not exist yet, so we need to create it.
@@ -40,11 +39,10 @@ async function initRSMQ(password, queueNames) {
   return rsmq;
 }
 
-function initDB(password) {
+function initDB() {
   const redisClient = redis.createClient({
     host: config.redis.options.host,
-    port: config.redis.options.port,
-    password
+    port: config.redis.options.port
   });
 
   // NOTE: This is unfortunately how the redis client docs recommend
@@ -59,15 +57,13 @@ function initDB(password) {
 }
 
 async function init() {
-  // NOTE: It's important to trim the secret file from whitespaces
-  const password = fs.readFileSync("/run/secrets/redis_pass", "utf8").trim();
   const { contracts, queueNames } = initContracts();
 
   return {
     contracts,
     queueNames,
-    rsmq: await initRSMQ(password, queueNames),
-    db: initDB(password),
+    rsmq: await initRSMQ(queueNames),
+    db: initDB(),
     web3: web3
   };
 }


### PR DESCRIPTION
Fixes #4 

Note: I've also tried out AWS ECS as part of solving #4 but the effort failed: https://github.com/leapdao/challenge-services/pull/7

TODOs:

- [x] Remove redis password for easier handling
- [x] Add image to quay.io leapdao account
- [x] Remove config file from docker image and add as a volume 
- [x] Add watchtower for continous deployment (will follow up with #3)
- [x] Deploy on AWS